### PR TITLE
Handle raw identifiers in to_pascal_case

### DIFF
--- a/structible-macros/src/util.rs
+++ b/structible-macros/src/util.rs
@@ -36,8 +36,12 @@ pub fn extract_option_inner(ty: &Type) -> Option<&Type> {
 }
 
 /// Converts a snake_case identifier to PascalCase.
+///
+/// Handles raw identifiers (e.g., `r#type`) by stripping the `r#` prefix.
 pub fn to_pascal_case(ident: &syn::Ident) -> syn::Ident {
     let s = ident.to_string();
+    // Strip the raw identifier prefix if present
+    let s = s.strip_prefix("r#").unwrap_or(&s);
     let pascal: String = s
         .split('_')
         .map(|part| {
@@ -62,6 +66,13 @@ mod tests {
         let ident = syn::Ident::new("foo_bar_baz", proc_macro2::Span::call_site());
         let result = to_pascal_case(&ident);
         assert_eq!(result.to_string(), "FooBarBaz");
+    }
+
+    #[test]
+    fn test_to_pascal_case_raw_identifier() {
+        let ident = syn::Ident::new_raw("type", proc_macro2::Span::call_site());
+        let result = to_pascal_case(&ident);
+        assert_eq!(result.to_string(), "Type");
     }
 
     #[test]

--- a/structible/tests/edge_cases.rs
+++ b/structible/tests/edge_cases.rs
@@ -168,3 +168,23 @@ fn test_lifetime_field() {
     assert_eq!(*obj.reference(), "hello");
     assert_eq!(obj.owned(), "world");
 }
+
+// Test raw identifiers (e.g., using Rust keywords as field names)
+#[structible]
+pub struct WithRawIdentifiers {
+    pub r#type: String,
+    pub r#match: Option<i32>,
+}
+
+#[test]
+fn test_raw_identifiers() {
+    let mut obj = WithRawIdentifiers::new("keyword".into());
+    assert_eq!(obj.r#type(), "keyword");
+    assert_eq!(obj.r#match(), None);
+
+    obj.set_match(Some(42));
+    assert_eq!(obj.r#match(), Some(&42));
+
+    obj.set_type("updated".into());
+    assert_eq!(obj.r#type(), "updated");
+}


### PR DESCRIPTION
Strip the `r#` prefix from raw identifiers before converting to PascalCase. This fixes issue #1 where fields like `r#type` would produce invalid enum variant names.