### PR TITLE
Make `len()` and `is_empty()` methods opt-in

### DIFF
--- a/structible-macros/src/codegen.rs
+++ b/structible-macros/src/codegen.rs
@@ -228,6 +228,22 @@ pub fn generate_impl(
     let unknown_methods = generate_unknown_field_methods(struct_name, fields, generics);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let len_methods = if config.with_len {
+        quote! {
+            /// Returns the number of fields currently present.
+            pub fn len(&self) -> usize {
+                ::structible::BackingMap::len(&self.inner)
+            }
+
+            /// Returns true if no fields are present.
+            pub fn is_empty(&self) -> bool {
+                ::structible::BackingMap::is_empty(&self.inner)
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     quote! {
         impl #impl_generics #struct_name #ty_generics #where_clause {
             #constructor
@@ -238,16 +254,7 @@ pub fn generate_impl(
             #(#take_methods)*
             #into_fields
             #unknown_methods
-
-            /// Returns the number of fields currently present.
-            pub fn len(&self) -> usize {
-                ::structible::BackingMap::len(&self.inner)
-            }
-
-            /// Returns true if no fields are present.
-            pub fn is_empty(&self) -> bool {
-                ::structible::BackingMap::is_empty(&self.inner)
-            }
+            #len_methods
         }
     }
 }

--- a/structible/tests/custom_backing.rs
+++ b/structible/tests/custom_backing.rs
@@ -39,7 +39,7 @@ impl<K: Ord, V> BackingMap<K, V> for MyMap<K, V> {
     }
 }
 
-#[structible(backing = MyMap)]
+#[structible(backing = MyMap, with_len)]
 pub struct Config {
     pub name: String,
     pub value: u32,


### PR DESCRIPTION
## Summary
- Add `with_len` attribute flag to control generation of `len()` and `is_empty()` methods
- Previously these were always generated, which exposed the underlying HashMap implementation
- Now users must explicitly opt-in via `#[structible(with_len)]`

## Breaking Change
Existing code using `.len()` or `.is_empty()` methods must add the `with_len` attribute:

```rust
// Before
#[structible]
pub struct Foo { ... }

// After
#[structible(with_len)]
pub struct Foo { ... }
```

## Test plan
- [x] All existing tests pass
- [x] `cargo clippy` passes without warnings
- [x] Updated `custom_backing.rs` tests to use `with_len`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)