### PR TITLE
Remove `take_*` methods for mandatory fields

### DIFF
--- a/structible-macros/src/codegen.rs
+++ b/structible-macros/src/codegen.rs
@@ -612,10 +612,10 @@ fn generate_removers(
         .collect()
 }
 
-/// Generate `take_*` methods for extracting owned values from fields.
+/// Generate `take_*` methods for extracting owned values from optional fields.
 ///
-/// Unlike `remove_*` (optional fields only), `take_*` is generated for all fields.
-/// Required fields panic if missing; optional fields return `Option<T>`.
+/// Only generated for optional fields to prevent leaving the struct in an invalid state.
+/// Use `into_fields()` to extract ownership of required fields.
 fn generate_take_methods(
     struct_name: &Ident,
     fields: &[FieldInfo],
@@ -626,36 +626,20 @@ fn generate_take_methods(
 
     fields
         .iter()
-        .filter(|f| !f.is_unknown_field())
+        .filter(|f| f.is_optional && !f.is_unknown_field())
         .map(|f| {
             let name = &f.name;
             let take_name = format_ident!("take_{}", name);
             let variant = to_pascal_case(name);
             let vis = &f.vis;
+            let inner_ty = &f.inner_ty;
 
-            if f.is_optional {
-                let inner_ty = &f.inner_ty;
-                quote! {
-                    /// Removes and returns the field value if present.
-                    #vis fn #take_name(&mut self) -> Option<#inner_ty> {
-                        match ::structible::BackingMap::remove(&mut self.inner, &#field_enum::#variant) {
-                            Some(#value_enum::#variant(v)) => Some(v),
-                            _ => None,
-                        }
-                    }
-                }
-            } else {
-                let ty = &f.ty;
-                quote! {
-                    /// Removes and returns the field value.
-                    ///
-                    /// # Panics
-                    /// Panics if the field is not present (invariant violation).
-                    #vis fn #take_name(&mut self) -> #ty {
-                        match ::structible::BackingMap::remove(&mut self.inner, &#field_enum::#variant) {
-                            Some(#value_enum::#variant(v)) => v,
-                            _ => panic!("required field `{}` not present", stringify!(#name)),
-                        }
+            quote! {
+                /// Removes and returns the field value if present.
+                #vis fn #take_name(&mut self) -> Option<#inner_ty> {
+                    match ::structible::BackingMap::remove(&mut self.inner, &#field_enum::#variant) {
+                        Some(#value_enum::#variant(v)) => Some(v),
+                        _ => None,
                     }
                 }
             }

--- a/structible/tests/ownership_extraction.rs
+++ b/structible/tests/ownership_extraction.rs
@@ -42,17 +42,6 @@ fn test_pattern_matching_destructure() {
 }
 
 #[test]
-fn test_take_required_field() {
-    let mut person = Person::new("Diana".into(), 35);
-
-    let name = person.take_name();
-    assert_eq!(name, "Diana");
-
-    let age = person.take_age();
-    assert_eq!(age, 35);
-}
-
-#[test]
 fn test_take_optional_field_present() {
     let mut person = Person::new("Eve".into(), 28);
     person.set_email(Some("eve@example.com".into()));
@@ -70,25 +59,17 @@ fn test_take_optional_field_absent() {
 }
 
 #[test]
-#[should_panic(expected = "required field")]
-fn test_take_required_field_twice_panics() {
-    let mut person = Person::new("Grace".into(), 22);
-
-    let _name1 = person.take_name();
-    let _name2 = person.take_name(); // Should panic
-}
-
-#[test]
 fn test_take_does_not_consume_struct() {
     let mut person = Person::new("Henry".into(), 45);
     person.set_email(Some("henry@example.com".into()));
 
-    let name = person.take_name();
-    assert_eq!(name, "Henry");
+    // Take optional field
+    let email = person.take_email();
+    assert_eq!(email, Some("henry@example.com".into()));
 
-    // age and email still accessible
+    // Required fields still accessible via getters
+    assert_eq!(person.name(), "Henry");
     assert_eq!(*person.age(), 45);
-    assert_eq!(person.email(), Some(&"henry@example.com".into()));
 }
 
 // Generic struct test
@@ -112,9 +93,14 @@ fn test_generic_into_fields() {
 #[test]
 fn test_generic_take_methods() {
     let mut container = Container::new(vec![1, 2, 3]);
+    container.set_label(Some("test".into()));
 
-    let value = container.take_value();
-    assert_eq!(value, vec![1, 2, 3]);
+    // Only optional fields have take_* methods
+    let label = container.take_label();
+    assert_eq!(label, Some("test".into()));
+
+    // Required field still accessible via getter
+    assert_eq!(*container.value(), vec![1, 2, 3]);
 }
 
 #[test]
@@ -140,17 +126,6 @@ fn test_multiple_generics_into_fields() {
 
     assert_eq!(fields.key, "id");
     assert_eq!(fields.value, 123);
-}
-
-#[test]
-fn test_multiple_generics_take() {
-    let mut pair = Pair::new(1, "one");
-
-    let key = pair.take_key();
-    let value = pair.take_value();
-
-    assert_eq!(key, 1);
-    assert_eq!(value, "one");
 }
 
 // Test that Fields struct derives the expected traits


### PR DESCRIPTION
## Summary
- Only generate `take_*` methods for optional fields
- Previously, required fields had `take_*` methods that would panic if the field was missing after taking
- This could leave the struct in an invalid state, which is a type-safety violation

## Breaking Change
Code calling `take_*` on required fields will no longer compile. Use `into_fields()` instead to extract ownership of required fields:

```rust
// Before
let name = person.take_name();  // Now compile error

// After - use into_fields() for ownership extraction
let fields = person.into_fields();
let name = fields.name;
```

## Test plan
- [x] All existing tests pass
- [x] `cargo clippy` passes without warnings
- [x] Removed/updated tests that relied on `take_*` for required fields

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)