### PR TITLE
Replace `*Fields` companion struct with HashMap-backed approach

### DIFF
--- a/structible-macros/src/lib.rs
+++ b/structible-macros/src/lib.rs
@@ -42,8 +42,8 @@ use quote::quote;
 use syn::{ItemStruct, parse_macro_input};
 
 use crate::codegen::{
-    generate_default_impl, generate_field_enum, generate_fields_struct, generate_impl,
-    generate_struct, generate_value_enum,
+    generate_default_impl, generate_field_enum, generate_fields_impl, generate_fields_struct,
+    generate_impl, generate_struct, generate_value_enum,
 };
 use crate::parse::{StructibleConfig, parse_struct_fields};
 
@@ -85,7 +85,7 @@ use crate::parse::{StructibleConfig, parse_struct_fields};
 ///
 /// - `name()` returns `&String` (not `Option`)
 /// - `set_name(v)` replaces the value
-/// - `take_name()` extracts the owned value
+/// - Use `into_fields()` then `take_name()` to extract owned value
 #[proc_macro_attribute]
 pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
     let config = match syn::parse::<StructibleConfig>(attr) {
@@ -108,6 +108,7 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
     let field_enum = generate_field_enum(name, &fields);
     let value_enum = generate_value_enum(name, &fields, generics);
     let fields_struct = generate_fields_struct(name, vis, &fields, &config, generics);
+    let fields_impl = generate_fields_impl(name, &fields, &config, generics);
     let struct_def = generate_struct(name, vis, &config, attrs, generics);
     let impl_block = generate_impl(name, &fields, &config, generics);
     let default_impl = generate_default_impl(name, &fields, &config, generics);
@@ -116,6 +117,7 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
         #field_enum
         #value_enum
         #fields_struct
+        #fields_impl
         #struct_def
         #impl_block
         #default_impl

--- a/structible/tests/edge_cases.rs
+++ b/structible/tests/edge_cases.rs
@@ -102,10 +102,10 @@ pub struct AllOptional {
 #[test]
 fn test_into_fields_all_none() {
     let obj = AllOptional::default();
-    let fields = obj.into_fields();
-    assert_eq!(fields.a, None);
-    assert_eq!(fields.b, None);
-    assert_eq!(fields.c, None);
+    let mut fields = obj.into_fields();
+    assert_eq!(fields.take_a(), None);
+    assert_eq!(fields.take_b(), None);
+    assert_eq!(fields.take_c(), None);
 }
 
 #[test]
@@ -115,10 +115,10 @@ fn test_into_fields_all_some() {
     obj.set_b(Some(42));
     obj.set_c(Some(true));
 
-    let fields = obj.into_fields();
-    assert_eq!(fields.a, Some("hello".into()));
-    assert_eq!(fields.b, Some(42));
-    assert_eq!(fields.c, Some(true));
+    let mut fields = obj.into_fields();
+    assert_eq!(fields.take_a(), Some("hello".into()));
+    assert_eq!(fields.take_b(), Some(42));
+    assert_eq!(fields.take_c(), Some(true));
 }
 
 #[test]
@@ -126,10 +126,10 @@ fn test_into_fields_mixed() {
     let mut obj = AllOptional::default();
     obj.set_b(Some(100));
 
-    let fields = obj.into_fields();
-    assert_eq!(fields.a, None);
-    assert_eq!(fields.b, Some(100));
-    assert_eq!(fields.c, None);
+    let mut fields = obj.into_fields();
+    assert_eq!(fields.take_a(), None);
+    assert_eq!(fields.take_b(), Some(100));
+    assert_eq!(fields.take_c(), None);
 }
 
 // Test BTreeMap backing with unknown fields


### PR DESCRIPTION
## Summary
- Redesign `*Fields` companion struct to use HashMap backing instead of inline fields
- All fields (required and optional) now extracted via `take_*` methods returning `Option<T>`
- Implements "reverse builder" pattern - fields can only be extracted, not inserted
- More stack-friendly for structs with many large fields

## Design

Per issue #5 requirements:
1. `FooFields` has `inner: HashMap<FieldEnum, ValueEnum>` like `Foo`
2. Every field is optional (even mandatory ones from `Foo`)
3. Fields extracted safely via `take_*` methods
4. No reinsertion - "reverse builder" pattern

For unknown fields:
- `take_*(key)` - extract individual unknown field
- `*_iter()` - iterate over remaining unknown fields
- `drain_*()` - extract all unknown fields into a new map

## Breaking Change

This is a significant API change:

```rust
// Before - pattern matching
let PersonFields { name, age, email } = person.into_fields();

// After - take_* methods
let mut fields = person.into_fields();
let name = fields.take_name().expect("required field");
let age = fields.take_age().expect("required field");
let email = fields.take_email();
```

## Test plan
- [x] All existing tests pass (updated for new API)
- [x] `cargo clippy` passes without warnings
- [x] Added test for `drain_*()` method with unknown fields
- [x] Verified take returns `None` after first extraction

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)