### PR TITLE
Make Debug impls mimic normal struct output

### DIFF
--- a/structible-macros/src/lib.rs
+++ b/structible-macros/src/lib.rs
@@ -42,8 +42,9 @@ use quote::quote;
 use syn::{ItemStruct, parse_macro_input};
 
 use crate::codegen::{
-    generate_default_impl, generate_field_enum, generate_fields_impl, generate_fields_struct,
-    generate_impl, generate_struct, generate_value_enum,
+    generate_debug_impl, generate_default_impl, generate_field_enum, generate_fields_debug_impl,
+    generate_fields_impl, generate_fields_struct, generate_impl, generate_struct,
+    generate_value_enum,
 };
 use crate::parse::{StructibleConfig, parse_struct_fields};
 
@@ -109,7 +110,9 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
     let value_enum = generate_value_enum(name, &fields, generics);
     let fields_struct = generate_fields_struct(name, vis, &fields, &config, generics);
     let fields_impl = generate_fields_impl(name, &fields, &config, generics);
+    let fields_debug_impl = generate_fields_debug_impl(name, &fields, generics);
     let struct_def = generate_struct(name, vis, &config, attrs, generics);
+    let debug_impl = generate_debug_impl(name, &fields, generics);
     let impl_block = generate_impl(name, &fields, &config, generics);
     let default_impl = generate_default_impl(name, &fields, &config, generics);
 
@@ -118,7 +121,9 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
         #value_enum
         #fields_struct
         #fields_impl
+        #fields_debug_impl
         #struct_def
+        #debug_impl
         #impl_block
         #default_impl
     };

--- a/structible/tests/debug_output.rs
+++ b/structible/tests/debug_output.rs
@@ -1,0 +1,105 @@
+//! Tests for the Debug output format.
+//!
+//! Verifies that Debug output shows fields like a normal struct,
+//! with only present fields displayed.
+
+use structible::structible;
+
+#[structible]
+struct Person {
+    name: String,
+    age: u32,
+    email: Option<String>,
+}
+
+#[structible]
+struct AllOptional {
+    first: Option<String>,
+    second: Option<i32>,
+    third: Option<bool>,
+}
+
+#[structible]
+struct WithUnknown {
+    name: String,
+    #[structible(key = String)]
+    extra: Option<String>,
+}
+
+#[test]
+fn test_debug_shows_required_fields() {
+    let person = Person::new("Alice".to_string(), 30);
+    let debug_str = format!("{:?}", person);
+
+    // Should show the struct name and present fields
+    assert!(debug_str.starts_with("Person {"));
+    assert!(debug_str.contains("name: \"Alice\""));
+    assert!(debug_str.contains("age: 30"));
+    // email is not set, should not appear
+    assert!(!debug_str.contains("email"));
+}
+
+#[test]
+fn test_debug_shows_optional_fields_when_present() {
+    let mut person = Person::new("Bob".to_string(), 25);
+    person.set_email(Some("bob@example.com".to_string()));
+    let debug_str = format!("{:?}", person);
+
+    assert!(debug_str.contains("name: \"Bob\""));
+    assert!(debug_str.contains("age: 25"));
+    assert!(debug_str.contains("email: \"bob@example.com\""));
+}
+
+#[test]
+fn test_debug_empty_struct() {
+    let empty = AllOptional::default();
+    let debug_str = format!("{:?}", empty);
+
+    // Should just show the struct name with no fields
+    assert_eq!(debug_str, "AllOptional");
+}
+
+#[test]
+fn test_debug_partial_fields() {
+    let mut partial = AllOptional::default();
+    partial.set_second(Some(42));
+    let debug_str = format!("{:?}", partial);
+
+    assert!(debug_str.starts_with("AllOptional {"));
+    assert!(debug_str.contains("second: 42"));
+    assert!(!debug_str.contains("first"));
+    assert!(!debug_str.contains("third"));
+}
+
+#[test]
+fn test_debug_with_unknown_fields() {
+    let mut item = WithUnknown::new("test".to_string());
+    item.add_extra("custom_key".to_string(), "custom_value".to_string());
+    let debug_str = format!("{:?}", item);
+
+    assert!(debug_str.contains("name: \"test\""));
+    assert!(debug_str.contains("\"custom_key\": \"custom_value\""));
+}
+
+#[test]
+fn test_debug_fields_struct() {
+    let person = Person::new("Charlie".to_string(), 35);
+    let fields = person.into_fields();
+    let debug_str = format!("{:?}", fields);
+
+    // Fields struct should also have custom Debug
+    assert!(debug_str.starts_with("PersonFields {"));
+    assert!(debug_str.contains("name: \"Charlie\""));
+    assert!(debug_str.contains("age: 35"));
+}
+
+#[test]
+fn test_debug_alternate_format() {
+    let mut person = Person::new("Diana".to_string(), 28);
+    person.set_email(Some("diana@example.com".to_string()));
+    let debug_str = format!("{:#?}", person);
+
+    // Alternate format should be multi-line
+    assert!(debug_str.contains('\n'));
+    assert!(debug_str.contains("name: \"Diana\""));
+}


### PR DESCRIPTION
## Summary

- Replace derived `Debug` with custom implementations using `DebugStruct` that show only present fields
- Makes output more readable and hides the internal map-backed implementation detail
- Unknown fields display with their key as the field name
- Debug bounds are added to type parameters in generic structs

### Before
```
Person { inner: { Name: Name("Alice"), Age: Age(30) } }
```

### After
```
Person { name: "Alice", age: 30 }
```

## Test plan

- [x] Added `structible/tests/debug_output.rs` with 7 tests covering:
  - Required fields display
  - Optional fields display when present
  - Empty struct output
  - Partial fields
  - Unknown fields
  - Fields struct debug
  - Alternate format
- [x] All existing tests pass
- [x] Clippy clean

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)