### PR TITLE
Add unreleased changes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- `Debug` implementations now show fields like normal structs instead of exposing internal map structure
+- Only present fields are shown in `Debug` output (sparse representation)
+- Extended documentation generation to cover all generated methods (getters, mutable getters, setters)
+- Updated README to document `with_len`, `take_*` methods, and ownership extraction
+
 ## [0.2.0] - 2026-02-16
 
 ### Changed


### PR DESCRIPTION
## Summary

Documents pending changes from PRs #12, #13, and #14:

### Changed
- `Debug` implementations now show fields like normal structs instead of exposing internal map structure
- Only present fields are shown in `Debug` output (sparse representation)

### Added
- Documentation for all generated methods (getters, mutable getters, setters)

### Documentation
- Added `with_len` attribute to README quick reference
- Added `take_*` method for optional fields to README
- Fixed ownership extraction examples in README

## Test plan

- [x] CHANGELOG follows Keep a Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)