### PR TITLE
Change optional field setters to take T instead of Option<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ let mut person = Person::new("Alice".into(), 30);
 assert_eq!(person.name(), "Alice");
 assert_eq!(*person.age(), 30);
 
-person.set_email(Some("alice@example.com".into()));
+person.set_email("alice@example.com".into());
 assert_eq!(person.email(), Some(&"alice@example.com".into()));
 
 *person.age_mut() += 1;
@@ -54,7 +54,7 @@ For each field, the macro generates:
 | Required | Setter | `fn set_name(&mut self, value: T)` |
 | Optional | Getter | `fn name(&self) -> Option<&T>` |
 | Optional | Mutable getter | `fn name_mut(&mut self) -> Option<&mut T>` |
-| Optional | Setter | `fn set_name(&mut self, value: Option<T>)` |
+| Optional | Setter | `fn set_name(&mut self, value: T)` |
 | Optional | Remover | `fn remove_name(&mut self) -> Option<T>` |
 | Optional | Take | `fn take_name(&mut self) -> Option<T>` |
 
@@ -116,7 +116,7 @@ For optional fields, you can also use `take_*` directly on the struct without co
 
 ```rust,ignore
 let mut person = Person::new("Bob".into(), 25);
-person.set_email(Some("bob@example.com".into()));
+person.set_email("bob@example.com".into());
 
 let email = person.take_email(); // Some("bob@example.com")
 // person.email() is now None, but person is still valid

--- a/structible-macros/src/codegen.rs
+++ b/structible-macros/src/codegen.rs
@@ -689,30 +689,13 @@ fn generate_setters(
             let vis = &f.vis;
 
             let name_str = name.to_string();
-            if f.is_optional {
-                let inner_ty = &f.inner_ty;
-                let doc = format!("Sets the `{}` value. Pass `None` to remove.", name_str);
-                quote! {
-                    #[doc = #doc]
-                    #vis fn #setter_name(&mut self, value: Option<#inner_ty>) {
-                        match value {
-                            Some(v) => {
-                                ::structible::BackingMap::insert(&mut self.inner, #field_enum::#variant, #value_enum::#variant(v));
-                            }
-                            None => {
-                                ::structible::BackingMap::remove(&mut self.inner, &#field_enum::#variant);
-                            }
-                        }
-                    }
-                }
-            } else {
-                let ty = &f.ty;
-                let doc = format!("Sets the `{}` value.", name_str);
-                quote! {
-                    #[doc = #doc]
-                    #vis fn #setter_name(&mut self, value: #ty) {
-                        ::structible::BackingMap::insert(&mut self.inner, #field_enum::#variant, #value_enum::#variant(value));
-                    }
+            let doc = format!("Sets the `{}` value.", name_str);
+            // Use inner_ty for optional fields, ty for required fields
+            let value_ty = if f.is_optional { &f.inner_ty } else { &f.ty };
+            quote! {
+                #[doc = #doc]
+                #vis fn #setter_name(&mut self, value: #value_ty) {
+                    ::structible::BackingMap::insert(&mut self.inner, #field_enum::#variant, #value_enum::#variant(value));
                 }
             }
         })

--- a/structible/tests/custom_backing.rs
+++ b/structible/tests/custom_backing.rs
@@ -53,7 +53,7 @@ fn test_custom_backing_type() {
     assert_eq!(*config.value(), 42);
     assert_eq!(config.description(), None);
 
-    config.set_description(Some("A test config".into()));
+    config.set_description("A test config".into());
     assert_eq!(config.description(), Some(&"A test config".to_string()));
 
     *config.value_mut() = 100;
@@ -66,7 +66,7 @@ fn test_custom_backing_type() {
 #[test]
 fn test_custom_backing_remove() {
     let mut config = Config::new("test".into(), 42);
-    config.set_description(Some("desc".into()));
+    config.set_description("desc".into());
 
     let removed = config.remove_description();
     assert_eq!(removed, Some("desc".to_string()));

--- a/structible/tests/debug_output.rs
+++ b/structible/tests/debug_output.rs
@@ -42,7 +42,7 @@ fn test_debug_shows_required_fields() {
 #[test]
 fn test_debug_shows_optional_fields_when_present() {
     let mut person = Person::new("Bob".to_string(), 25);
-    person.set_email(Some("bob@example.com".to_string()));
+    person.set_email("bob@example.com".to_string());
     let debug_str = format!("{:?}", person);
 
     assert!(debug_str.contains("name: \"Bob\""));
@@ -62,7 +62,7 @@ fn test_debug_empty_struct() {
 #[test]
 fn test_debug_partial_fields() {
     let mut partial = AllOptional::default();
-    partial.set_second(Some(42));
+    partial.set_second(42);
     let debug_str = format!("{:?}", partial);
 
     assert!(debug_str.starts_with("AllOptional {"));
@@ -96,7 +96,7 @@ fn test_debug_fields_struct() {
 #[test]
 fn test_debug_alternate_format() {
     let mut person = Person::new("Diana".to_string(), 28);
-    person.set_email(Some("diana@example.com".to_string()));
+    person.set_email("diana@example.com".to_string());
     let debug_str = format!("{:#?}", person);
 
     // Alternate format should be multi-line

--- a/structible/tests/edge_cases.rs
+++ b/structible/tests/edge_cases.rs
@@ -28,7 +28,7 @@ fn test_btreemap_backing() {
     assert_eq!(*obj.count(), 42);
     assert_eq!(obj.label(), None);
 
-    obj.set_label(Some("my label".into()));
+    obj.set_label("my label".into());
     assert_eq!(obj.label(), Some(&"my label".to_string()));
 }
 
@@ -70,7 +70,7 @@ fn test_array_field() {
     assert_eq!(*obj.data(), [1, 2, 3, 4]);
     assert_eq!(obj.optional_data(), None);
 
-    obj.set_optional_data(Some([10, 20, 30]));
+    obj.set_optional_data([10, 20, 30]);
     assert_eq!(obj.optional_data(), Some(&[10, 20, 30]));
 }
 
@@ -111,9 +111,9 @@ fn test_into_fields_all_none() {
 #[test]
 fn test_into_fields_all_some() {
     let mut obj = AllOptional::default();
-    obj.set_a(Some("hello".into()));
-    obj.set_b(Some(42));
-    obj.set_c(Some(true));
+    obj.set_a("hello".into());
+    obj.set_b(42);
+    obj.set_c(true);
 
     let mut fields = obj.into_fields();
     assert_eq!(fields.take_a(), Some("hello".into()));
@@ -124,7 +124,7 @@ fn test_into_fields_all_some() {
 #[test]
 fn test_into_fields_mixed() {
     let mut obj = AllOptional::default();
-    obj.set_b(Some(100));
+    obj.set_b(100);
 
     let mut fields = obj.into_fields();
     assert_eq!(fields.take_a(), None);
@@ -182,7 +182,7 @@ fn test_raw_identifiers() {
     assert_eq!(obj.r#type(), "keyword");
     assert_eq!(obj.r#match(), None);
 
-    obj.set_match(Some(42));
+    obj.set_match(42);
     assert_eq!(obj.r#match(), Some(&42));
 
     obj.set_type("updated".into());

--- a/structible/tests/ownership_extraction.rs
+++ b/structible/tests/ownership_extraction.rs
@@ -10,7 +10,7 @@ pub struct Person {
 #[test]
 fn test_into_fields_all_present() {
     let mut person = Person::new("Alice".into(), 30);
-    person.set_email(Some("alice@example.com".into()));
+    person.set_email("alice@example.com".into());
 
     let mut fields = person.into_fields();
 
@@ -37,7 +37,7 @@ fn test_into_fields_optional_missing() {
 #[test]
 fn test_take_fields_individually() {
     let mut person = Person::new("Charlie".into(), 40);
-    person.set_email(Some("charlie@example.com".into()));
+    person.set_email("charlie@example.com".into());
 
     let mut fields = person.into_fields();
 
@@ -70,7 +70,7 @@ fn test_take_returns_none_after_first_take() {
 #[test]
 fn test_take_optional_field_present() {
     let mut person = Person::new("Eve".into(), 28);
-    person.set_email(Some("eve@example.com".into()));
+    person.set_email("eve@example.com".into());
 
     let mut fields = person.into_fields();
 
@@ -98,7 +98,7 @@ pub struct Container<T> {
 #[test]
 fn test_generic_into_fields() {
     let mut container = Container::new(42i32);
-    container.set_label(Some("answer".into()));
+    container.set_label("answer".into());
 
     let mut fields = container.into_fields();
 
@@ -109,7 +109,7 @@ fn test_generic_into_fields() {
 #[test]
 fn test_generic_take_methods() {
     let mut container = Container::new(vec![1, 2, 3]);
-    container.set_label(Some("test".into()));
+    container.set_label("test".into());
 
     let mut fields = container.into_fields();
 
@@ -182,7 +182,7 @@ mod visibility_test {
     #[test]
     fn test_fields_take_visibility() {
         let mut item = MixedVisibility::new("hello".into(), 42);
-        item.set_private_field(Some(true));
+        item.set_private_field(true);
 
         let mut fields = item.into_fields();
 

--- a/structible/tests/rfc8984-location.rs
+++ b/structible/tests/rfc8984-location.rs
@@ -23,7 +23,7 @@ struct Location<V> {
 #[test]
 fn basic_usage() {
     let mut location = Location::<bool>::new("Sydney".into());
-    location.set_links(Some(HashMap::new()));
+    location.set_links(HashMap::new());
     location.add_vendor_property("example.com:foo".into(), true);
     location.add_vendor_property("example.com:bar".into(), false);
 


### PR DESCRIPTION
## Summary

- Setters for optional fields now take `T` directly instead of `Option<T>`
- Removal of optional fields is done via the existing `remove_*` methods
- Simplifies the API and removes redundancy

## Motivation

Previously, `set_email(None)` and `remove_email()` both removed the field, but only `remove_email()` returned the old value. There was no compelling reason to prefer one over the other, and requiring `Some()` wrappers made the common case more verbose.

## Changes

**Before:**
```rust
person.set_email(Some("alice@example.com".into()));
```

**After:**
```rust
person.set_email("alice@example.com".into());
```

## Test plan

- [x] All existing tests pass (after removing `Some()` wrappers)
- [x] `cargo clippy` passes
- [x] README.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)