### PR TITLE
Rename add_* to insert_* for unknown fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ When a field has `#[structible(key = KeyType)]`, it becomes a catch-all for unkn
 - At most one unknown field per struct
 
 **Generated methods on main struct:**
-- `add_<field>(key, value)` - Insert unknown field, returns previous value if present
+- `insert_<field>(key, value)` - Insert unknown field, returns previous value if present
 - `<field>(&key)` - Get by borrowed key (supports `Borrow` trait)
 - `<field>_mut(&key)` - Mutable access by borrowed key
 - `remove_<field>(&key)` - Remove and return value

--- a/structible-macros/src/codegen.rs
+++ b/structible-macros/src/codegen.rs
@@ -718,7 +718,7 @@ fn generate_unknown_field_methods(
     let vis = &unknown_field.vis;
 
     // Method names derived from field name
-    let add_method = format_ident!("add_{}", name);
+    let insert_method = format_ident!("insert_{}", name);
     let get_method = name.clone();
     let get_mut_method = format_ident!("{}_mut", name);
     let remove_method = format_ident!("remove_{}", name);
@@ -727,7 +727,7 @@ fn generate_unknown_field_methods(
     quote! {
         /// Inserts an unknown field with the given key and value.
         /// Returns the previous value if the key was already present.
-        #vis fn #add_method(&mut self, key: #key_type, value: #value_type) -> Option<#value_type> {
+        #vis fn #insert_method(&mut self, key: #key_type, value: #value_type) -> Option<#value_type> {
             match ::structible::BackingMap::insert(
                 &mut self.inner,
                 #field_enum::Unknown(key),

--- a/structible/tests/custom_backing.rs
+++ b/structible/tests/custom_backing.rs
@@ -110,8 +110,8 @@ fn test_custom_backing_with_unknown_fields() {
     assert_eq!(config.name(), "test");
 
     // Add unknown fields
-    config.add_extra("color".into(), "blue".into());
-    config.add_extra("size".into(), "large".into());
+    config.insert_extra("color".into(), "blue".into());
+    config.insert_extra("size".into(), "large".into());
 
     // Look up by borrowed key
     assert_eq!(config.extra("color"), Some(&"blue".to_string()));

--- a/structible/tests/debug_output.rs
+++ b/structible/tests/debug_output.rs
@@ -74,7 +74,7 @@ fn test_debug_partial_fields() {
 #[test]
 fn test_debug_with_unknown_fields() {
     let mut item = WithUnknown::new("test".to_string());
-    item.add_extra("custom_key".to_string(), "custom_value".to_string());
+    item.insert_extra("custom_key".to_string(), "custom_value".to_string());
     let debug_str = format!("{:?}", item);
 
     assert!(debug_str.contains("name: \"test\""));

--- a/structible/tests/edge_cases.rs
+++ b/structible/tests/edge_cases.rs
@@ -143,8 +143,8 @@ pub struct BTreeMapWithUnknown {
 #[test]
 fn test_btreemap_with_unknown() {
     let mut obj = BTreeMapWithUnknown::new("test".into());
-    obj.add_extra("key1".into(), "value1".into());
-    obj.add_extra("key2".into(), "value2".into());
+    obj.insert_extra("key1".into(), "value1".into());
+    obj.insert_extra("key2".into(), "value2".into());
 
     // BTreeMap iteration should be ordered
     let entries: Vec<_> = obj.extra_iter().collect();

--- a/structible/tests/rfc8984-location.rs
+++ b/structible/tests/rfc8984-location.rs
@@ -24,8 +24,8 @@ struct Location<V> {
 fn basic_usage() {
     let mut location = Location::<bool>::new("Sydney".into());
     location.set_links(HashMap::new());
-    location.add_vendor_property("example.com:foo".into(), true);
-    location.add_vendor_property("example.com:bar".into(), false);
+    location.insert_vendor_property("example.com:foo".into(), true);
+    location.insert_vendor_property("example.com:bar".into(), false);
 
     assert_eq!(location.len(), 4);
     assert_eq!(location.vendor_property("example.com:foo"), Some(&true));

--- a/structible/tests/unknown_fields.rs
+++ b/structible/tests/unknown_fields.rs
@@ -16,21 +16,21 @@ fn test_basic_fields() {
 }
 
 #[test]
-fn test_add_unknown_field() {
+fn test_insert_unknown_field() {
     let mut person = Person::new("Alice".into(), 30);
 
     // Add an unknown field
-    let prev = person.add_extra("favorite_color".into(), "blue".into());
+    let prev = person.insert_extra("favorite_color".into(), "blue".into());
     assert!(prev.is_none());
 
     // Add another
-    person.add_extra("city".into(), "NYC".into());
+    person.insert_extra("city".into(), "NYC".into());
 }
 
 #[test]
 fn test_get_unknown_field() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("favorite_color".into(), "blue".into());
+    person.insert_extra("favorite_color".into(), "blue".into());
 
     // Get by borrowed key
     let color = person.extra("favorite_color");
@@ -44,7 +44,7 @@ fn test_get_unknown_field() {
 #[test]
 fn test_get_mut_unknown_field() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("score".into(), "100".into());
+    person.insert_extra("score".into(), "100".into());
 
     // Mutate via get_mut
     if let Some(score) = person.extra_mut("score") {
@@ -57,7 +57,7 @@ fn test_get_mut_unknown_field() {
 #[test]
 fn test_remove_unknown_field() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("temp".into(), "value".into());
+    person.insert_extra("temp".into(), "value".into());
 
     let removed = person.remove_extra("temp");
     assert_eq!(removed, Some("value".to_string()));
@@ -69,8 +69,8 @@ fn test_remove_unknown_field() {
 #[test]
 fn test_remove_with_borrowed_str() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("key1".into(), "value1".into());
-    person.add_extra("key2".into(), "value2".into());
+    person.insert_extra("key1".into(), "value1".into());
+    person.insert_extra("key2".into(), "value2".into());
 
     // Remove using &str directly (the ergonomic API)
     let removed = person.remove_extra("key1");
@@ -85,7 +85,7 @@ fn test_remove_with_borrowed_str() {
 #[test]
 fn test_remove_with_owned_string_ref() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("mykey".into(), "myvalue".into());
+    person.insert_extra("mykey".into(), "myvalue".into());
 
     // Remove using &String (backwards compatibility)
     let key = String::from("mykey");
@@ -96,7 +96,7 @@ fn test_remove_with_owned_string_ref() {
 #[test]
 fn test_remove_nonexistent_key() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("exists".into(), "value".into());
+    person.insert_extra("exists".into(), "value".into());
 
     // Removing a key that doesn't exist returns None
     let removed = person.remove_extra("does_not_exist");
@@ -109,7 +109,7 @@ fn test_remove_nonexistent_key() {
 #[test]
 fn test_remove_same_key_twice() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("once".into(), "only".into());
+    person.insert_extra("once".into(), "only".into());
 
     // First removal succeeds
     let first = person.remove_extra("once");
@@ -123,8 +123,8 @@ fn test_remove_same_key_twice() {
 #[test]
 fn test_iterate_unknown_fields() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("a".into(), "1".into());
-    person.add_extra("b".into(), "2".into());
+    person.insert_extra("a".into(), "1".into());
+    person.insert_extra("b".into(), "2".into());
 
     let entries: Vec<_> = person.extra_iter().collect();
     assert_eq!(entries.len(), 2);
@@ -133,8 +133,8 @@ fn test_iterate_unknown_fields() {
 #[test]
 fn test_into_fields_with_unknown() {
     let mut person = Person::new("Alice".into(), 30);
-    person.add_extra("color".into(), "blue".into());
-    person.add_extra("size".into(), "medium".into());
+    person.insert_extra("color".into(), "blue".into());
+    person.insert_extra("size".into(), "medium".into());
 
     let mut fields = person.into_fields();
 
@@ -157,8 +157,8 @@ fn test_into_fields_with_unknown() {
 #[test]
 fn test_into_fields_drain_unknown() {
     let mut person = Person::new("Bob".into(), 25);
-    person.add_extra("key1".into(), "val1".into());
-    person.add_extra("key2".into(), "val2".into());
+    person.insert_extra("key1".into(), "val1".into());
+    person.insert_extra("key2".into(), "val2".into());
 
     let mut fields = person.into_fields();
 


### PR DESCRIPTION
## Summary
- Renames the generated `add_<field>` method to `insert_<field>` for unknown/extension fields
- Follows standard Rust map API conventions where `insert` more clearly conveys that an existing entry may be replaced
- Updates all tests and documentation to use the new method name

Fixes #20

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)