### PR TITLE
Add *_iter_mut methods for unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `*_iter_mut()` methods for unknown/extension fields on both the main struct and `Fields` companion struct
+
 ## [0.3.0] - 2026-02-17
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,10 +99,12 @@ When a field has `#[structible(key = KeyType)]`, it becomes a catch-all for unkn
 - `<field>_mut(&key)` - Mutable access by borrowed key
 - `remove_<field>(&key)` - Remove and return value
 - `<field>_iter()` - Iterate over all unknown fields as `(&K, &V)` pairs
+- `<field>_iter_mut()` - Mutably iterate over all unknown fields as `(&K, &mut V)` pairs
 
 **Generated methods on Fields companion struct:**
 - `take_<field>(&key)` - Extract value for a specific unknown key
 - `<field>_iter()` - Iterate unknown fields
+- `<field>_iter_mut()` - Mutably iterate unknown fields
 - `drain_<field>()` - Drain all unknown fields into a new map
 
 ### Key Design Decisions

--- a/structible-macros/src/codegen.rs
+++ b/structible-macros/src/codegen.rs
@@ -209,6 +209,7 @@ fn generate_fields_unknown_methods(
 
     let take_method = format_ident!("take_{}", name);
     let iter_method = format_ident!("{}_iter", name);
+    let iter_mut_method = format_ident!("{}_iter_mut", name);
     let drain_method = format_ident!("drain_{}", name);
 
     quote! {
@@ -228,6 +229,16 @@ fn generate_fields_unknown_methods(
         /// Returns an iterator over all unknown fields.
         #vis fn #iter_method(&self) -> impl Iterator<Item = (&#key_type, &#value_type)> {
             ::structible::IterableMap::iter(&self.inner).filter_map(|(k, v)| {
+                match (k, v) {
+                    (#field_enum::Unknown(key), #value_enum::Unknown(value)) => Some((key, value)),
+                    _ => None,
+                }
+            })
+        }
+
+        /// Returns a mutable iterator over all unknown fields.
+        #vis fn #iter_mut_method(&mut self) -> impl Iterator<Item = (&#key_type, &mut #value_type)> {
+            ::structible::IterableMap::iter_mut(&mut self.inner).filter_map(|(k, v)| {
                 match (k, v) {
                     (#field_enum::Unknown(key), #value_enum::Unknown(value)) => Some((key, value)),
                     _ => None,
@@ -723,6 +734,7 @@ fn generate_unknown_field_methods(
     let get_mut_method = format_ident!("{}_mut", name);
     let remove_method = format_ident!("remove_{}", name);
     let iter_method = format_ident!("{}_iter", name);
+    let iter_mut_method = format_ident!("{}_iter_mut", name);
 
     quote! {
         /// Inserts an unknown field with the given key and value.
@@ -792,6 +804,16 @@ fn generate_unknown_field_methods(
         /// Returns an iterator over all unknown fields.
         #vis fn #iter_method(&self) -> impl Iterator<Item = (&#key_type, &#value_type)> {
             ::structible::IterableMap::iter(&self.inner).filter_map(|(k, v)| {
+                match (k, v) {
+                    (#field_enum::Unknown(key), #value_enum::Unknown(value)) => Some((key, value)),
+                    _ => None,
+                }
+            })
+        }
+
+        /// Returns a mutable iterator over all unknown fields.
+        #vis fn #iter_mut_method(&mut self) -> impl Iterator<Item = (&#key_type, &mut #value_type)> {
+            ::structible::IterableMap::iter_mut(&mut self.inner).filter_map(|(k, v)| {
                 match (k, v) {
                     (#field_enum::Unknown(key), #value_enum::Unknown(value)) => Some((key, value)),
                     _ => None,

--- a/structible/tests/unknown_fields.rs
+++ b/structible/tests/unknown_fields.rs
@@ -131,6 +131,22 @@ fn test_iterate_unknown_fields() {
 }
 
 #[test]
+fn test_iterate_mut_unknown_fields() {
+    let mut person = Person::new("Alice".into(), 30);
+    person.insert_extra("a".into(), "1".into());
+    person.insert_extra("b".into(), "2".into());
+
+    // Mutate all values via iter_mut
+    for (_key, value) in person.extra_iter_mut() {
+        *value = format!("modified_{}", value);
+    }
+
+    // Verify mutations
+    assert_eq!(person.extra("a"), Some(&"modified_1".to_string()));
+    assert_eq!(person.extra("b"), Some(&"modified_2".to_string()));
+}
+
+#[test]
 fn test_into_fields_with_unknown() {
     let mut person = Person::new("Alice".into(), 30);
     person.insert_extra("color".into(), "blue".into());
@@ -152,6 +168,24 @@ fn test_into_fields_with_unknown() {
 
     // After taking, they're gone
     assert_eq!(fields.take_extra("color"), None);
+}
+
+#[test]
+fn test_into_fields_iter_mut_unknown() {
+    let mut person = Person::new("Bob".into(), 25);
+    person.insert_extra("key1".into(), "val1".into());
+    person.insert_extra("key2".into(), "val2".into());
+
+    let mut fields = person.into_fields();
+
+    // Mutate all unknown fields via iter_mut
+    for (_key, value) in fields.extra_iter_mut() {
+        *value = format!("updated_{}", value);
+    }
+
+    // Verify mutations
+    assert_eq!(fields.take_extra("key1"), Some("updated_val1".to_string()));
+    assert_eq!(fields.take_extra("key2"), Some("updated_val2".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `*_iter_mut()` methods for unknown/extension fields on both the main struct and `Fields` companion struct
- Updates CHANGELOG.md and CLAUDE.md documentation
- Adds tests for the new methods

## Test plan

- [x] `cargo test` passes with new tests for `extra_iter_mut`
- [x] Verified both main struct and Fields struct have the new method

🤖 Generated with [Claude Code](https://claude.com/claude-code)