### PR TITLE
Add no_clone and no_partial_eq attribute flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Into:
    - `len()` and `is_empty()` (opt-in via `with_len`)
 6. Generated methods on `PersonFields` companion struct:
    - `take_<field>()` for ALL fields (required and optional), all return `Option<T>`
-7. Derived traits: both structs derive `Clone, PartialEq` with custom `Debug` impls (showing only present fields)
+7. Derived traits: both structs derive `Clone, PartialEq` by default (opt-out via `no_clone`, `no_partial_eq`) with custom `Debug` impls (showing only present fields)
 8. `Default` impl (only if all non-unknown fields are optional)
 
 ### Attribute Syntax
@@ -79,6 +79,8 @@ Into:
 - `#[structible(backing = BTreeMap)]` - Explicit backing type
 - `#[structible(backing = HashMap, constructor = create)]` - Custom constructor name
 - `#[structible(with_len)]` - Enable `len()` and `is_empty()` methods
+- `#[structible(no_clone)]` - Do not derive `Clone` on generated types (allows non-Clone field types like `&mut T`)
+- `#[structible(no_partial_eq)]` - Do not derive `PartialEq` on generated types (allows non-PartialEq field types like `Box<dyn Fn()>`)
 
 **Field-level:**
 - `#[structible(get = custom_getter)]` - Custom getter name (replaces default `<field>`)

--- a/structible-macros/src/lib.rs
+++ b/structible-macros/src/lib.rs
@@ -107,7 +107,7 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
     let generics = &input.generics;
 
     let field_enum = generate_field_enum(name, &fields);
-    let value_enum = generate_value_enum(name, &fields, generics);
+    let value_enum = generate_value_enum(name, &fields, &config, generics);
     let fields_struct = generate_fields_struct(name, vis, &fields, &config, generics);
     let fields_impl = generate_fields_impl(name, &fields, &config, generics);
     let fields_debug_impl = generate_fields_debug_impl(name, &fields, generics);

--- a/structible-macros/src/util.rs
+++ b/structible-macros/src/util.rs
@@ -128,9 +128,13 @@ mod tests {
 
     #[test]
     fn test_format_method_doc_with_field_docs() {
-        let field_docs = vec![" Field doc line 1".to_string(), " Field doc line 2".to_string()];
+        let field_docs = vec![
+            " Field doc line 1".to_string(),
+            " Field doc line 2".to_string(),
+        ];
         let result = format_method_doc("Auto doc.", &field_docs);
-        let expected_doc = "Auto doc.\n\n## Field Documentation\n Field doc line 1\n Field doc line 2";
+        let expected_doc =
+            "Auto doc.\n\n## Field Documentation\n Field doc line 1\n Field doc line 2";
         let expected = quote! { #[doc = #expected_doc] };
         assert_eq!(result.to_string(), expected.to_string());
     }

--- a/structible/tests/optional_derives.rs
+++ b/structible/tests/optional_derives.rs
@@ -1,0 +1,78 @@
+use structible::structible;
+
+// Test no_clone with a non-Clone type (mutable reference)
+#[structible(no_clone)]
+pub struct WithMutRef<'a> {
+    pub data: &'a mut i32,
+}
+
+#[test]
+fn test_no_clone_with_mut_ref() {
+    let mut value = 42;
+    let mut obj = WithMutRef::new(&mut value);
+    // data() returns &(&mut i32), so we need **
+    assert_eq!(**obj.data(), 42);
+    **obj.data_mut() = 100;
+    assert_eq!(**obj.data(), 100);
+}
+
+// A type that implements Clone but not PartialEq
+#[derive(Clone, Debug)]
+pub struct CloneButNoEq(pub i32);
+
+// Test no_partial_eq with a type that doesn't implement PartialEq
+#[structible(no_partial_eq)]
+pub struct WithNoEq {
+    pub data: CloneButNoEq,
+}
+
+#[test]
+fn test_no_partial_eq() {
+    let obj = WithNoEq::new(CloneButNoEq(42));
+    assert_eq!(obj.data().0, 42);
+
+    // Verify Clone still works when only no_partial_eq is specified
+    let _cloned = obj.clone();
+}
+
+// Test both flags together
+#[structible(no_clone, no_partial_eq)]
+pub struct WithBoth<'a> {
+    pub data: &'a mut i32,
+}
+
+#[test]
+fn test_both_flags() {
+    let mut value = 10;
+    let obj = WithBoth::new(&mut value);
+    assert_eq!(**obj.data(), 10);
+}
+
+// Test combined with other flags
+#[structible(no_clone, with_len)]
+pub struct CombinedWithLen<'a> {
+    pub data: &'a mut i32,
+    pub optional: Option<String>,
+}
+
+#[test]
+fn test_no_clone_with_len() {
+    let mut value = 5;
+    let mut obj = CombinedWithLen::new(&mut value);
+    assert_eq!(obj.len(), 1); // only required field
+    obj.set_optional("test".into());
+    assert_eq!(obj.len(), 2);
+}
+
+// Test that existing behavior is preserved (no flags = Clone + PartialEq)
+#[structible]
+pub struct Normal {
+    pub value: String,
+}
+
+#[test]
+fn test_normal_is_clone_and_partial_eq() {
+    let obj1 = Normal::new("hello".into());
+    let obj2 = obj1.clone();
+    assert_eq!(obj1, obj2);
+}


### PR DESCRIPTION
## Summary
- Adds `no_clone` attribute flag to skip deriving `Clone` on generated types
- Adds `no_partial_eq` attribute flag to skip deriving `PartialEq` on generated types
- Enables field types that don't implement these traits (e.g., `&mut T`, closures)

Fixes #19

## Test plan
- [x] `cargo test` passes with all new and existing tests
- [x] `cargo clippy` passes (existing warnings only)
- [x] New test file `structible/tests/optional_derives.rs` validates:
  - `no_clone` works with mutable references
  - `no_partial_eq` works with non-PartialEq types
  - Both flags can be combined
  - Combined with other flags like `with_len`
  - Existing behavior unchanged (without flags = Clone + PartialEq)

🤖 Generated with [Claude Code](https://claude.com/claude-code)