### PR TITLE
Fix generated trait impls for structs with associated type fields

### DIFF
--- a/structible-macros/Cargo.toml
+++ b/structible-macros/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["rust-patterns", "development-tools::procedural-macro-helpers"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", features = ["full", "visit"] }
 quote = "1"
 proc-macro2 = "1"

--- a/structible-macros/src/lib.rs
+++ b/structible-macros/src/lib.rs
@@ -43,8 +43,8 @@ use syn::{ItemStruct, parse_macro_input};
 
 use crate::codegen::{
     generate_debug_impl, generate_default_impl, generate_field_enum, generate_fields_debug_impl,
-    generate_fields_impl, generate_fields_struct, generate_impl, generate_struct,
-    generate_value_enum,
+    generate_fields_impl, generate_fields_struct, generate_fields_struct_trait_impls, generate_impl,
+    generate_struct, generate_struct_trait_impls, generate_value_enum,
 };
 use crate::parse::{StructibleConfig, parse_struct_fields};
 
@@ -110,8 +110,10 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
     let fields_struct = generate_fields_struct(name, vis, &fields, &config, generics);
     let fields_impl = generate_fields_impl(name, &fields, &config, generics);
     let fields_debug_impl = generate_fields_debug_impl(name, &fields, generics);
+    let fields_trait_impls = generate_fields_struct_trait_impls(name, &fields, &config, generics);
     let struct_def = generate_struct(name, vis, &config, attrs, generics);
     let debug_impl = generate_debug_impl(name, &fields, generics);
+    let struct_trait_impls = generate_struct_trait_impls(name, &fields, &config, generics);
     let impl_block = generate_impl(name, &fields, &config, generics);
     let default_impl = generate_default_impl(name, &fields, &config, generics);
 
@@ -121,8 +123,10 @@ pub fn structible(attr: TokenStream, item: TokenStream) -> TokenStream {
         #fields_struct
         #fields_impl
         #fields_debug_impl
+        #fields_trait_impls
         #struct_def
         #debug_impl
+        #struct_trait_impls
         #impl_block
         #default_impl
     };

--- a/structible/tests/complex_generics.rs
+++ b/structible/tests/complex_generics.rs
@@ -1,6 +1,36 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
+// Regression test for issue #27: associated types in field types should work with
+// generated Debug, Clone, and PartialEq impls.
+trait JsonValue {
+    type String: Clone + PartialEq + Debug + Default;
+    type Array: Clone + PartialEq + Debug + Default;
+    type Object: Clone + PartialEq + Debug + Default;
+}
+
+#[structible]
+struct Table<V: JsonValue> {
+    pub string: V::String,
+    pub opt_string: Option<V::String>,
+    pub object: V::Object,
+}
+
+struct MyJson;
+impl JsonValue for MyJson {
+    type String = std::string::String;
+    type Array = Vec<i32>;
+    type Object = std::collections::HashMap<std::string::String, i32>;
+}
+
+#[test]
+fn test_associated_type_fields() {
+    let t = Table::<MyJson>::new(Default::default(), Default::default());
+    let cloned = t.clone();
+    assert_eq!(t, cloned);
+    let _ = format!("{:?}", t);
+}
+
 use structible::structible;
 
 #[structible]


### PR DESCRIPTION
## Summary

- Replaces `#[derive(Debug, Clone, PartialEq)]` on the generated value enum (and `derive` on the main struct / `Fields` struct) with manually-generated impls that bound on the actual field inner types rather than the raw type parameters
- Adds a `type_mentions_type_param` helper (using `syn::visit`) to filter bounds to only types that reference a struct's type parameters, avoiding `E0283` ambiguity on blanket-impl types like `&'a str`
- Adds `syn` `"visit"` feature to `Cargo.toml`
- Adds regression test `test_associated_type_fields` in `complex_generics.rs`

Fixes #27.

### Root cause

When a struct uses associated types of generic parameters in field types (e.g. `V::String` where `V: JsonValue`), the generated `Debug`/`Clone`/`PartialEq` impls added `V: Trait` bounds. But `V: Clone` does **not** imply `V::String: Clone`, so the generated code failed to compile.

### Fix

Manual impls are generated with where clauses like `where V::String: Clone, V::Object: Clone`. The bound types are filtered to those that syntactically reference one of the struct's type parameters so that reference types like `&'a str` (covered by blanket impls) are not added, which would cause `E0283` ambiguity errors.

## Test plan

- `cargo test -p structible` — all tests pass, including new `test_associated_type_fields`
- `cargo test -p structible-macros` — all unit tests pass
- `cargo clippy` — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)